### PR TITLE
Feature: Implement 3D Conformer handling via ConformerTable projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Implements database-like table structures for managing groups of chemical entiti
 * `features`: A dictionary mapping string identifiers to numerical arrays (e.g., molecular fingerprints).
 * `history`: An internal audit log that records pipeline transformations applied to the table.
 
-Concrete implementations include `MoleculeTable` and `ReactionTable`.
+Concrete implementations include `MoleculeTable`, `ConformerTable`, and `ReactionTable`.
 
 ### 3. `druglab.pipe`
 A framework for constructing sequential processing pipelines to update, filter, and featurize tables.

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,6 @@ This file uses a priority-based Kanban-style structure to track upcoming feature
 ### `druglab.db`
 🔴 **Improved Table Saving/Loading Schemes:** Create QoL improvements to the table storage schemes such as saving all objects in one file (currently each is saved separately in a directory).
 🟡 **External Database Bridging:** Add capabilities to dump/load `metadata` and `features` directly to/from SQL databases (SQLite/PostgreSQL) instead of just local directories.
-🟡 **3D Conformer Table:** Create a `ConformerTable` (subclass of `MoleculeTable` or new) specifically optimized for handling multi-conformer ensembles and 3D coordinates.
 🟢 **Memory-Mapped Optimization:** Automatically switch to `mmap` for `BaseTable.features` on table creation/modification if feature arrays exceed a specific RAM threshold.
 
 ### `druglab.pipe`
@@ -35,4 +34,4 @@ This file uses a priority-based Kanban-style structure to track upcoming feature
 ---
 
 ## ✅ Completed
-...
+🟡 **3D Conformer Table:** Create a `ConformerTable` (subclass of `MoleculeTable` or new) specifically optimized for handling multi-conformer ensembles and 3D coordinates.

--- a/src/druglab/db/__init__.py
+++ b/src/druglab/db/__init__.py
@@ -17,15 +17,22 @@ MoleculeTable
 
 ReactionTable
     Concrete subclass for RDKit ChemicalReaction objects.
+
+ConformerTable
+    Subclass of MoleculeTable where every row holds exactly one conformer.
+    Created via ``MoleculeTable.unroll_conformers()`` and collapsed back
+    via ``ConformerTable.collapse()`` or ``MoleculeTable.update_from_conformers()``.
 """
 
 from druglab.db.base import BaseTable, HistoryEntry
 from druglab.db.molecule import MoleculeTable
 from druglab.db.reaction import ReactionTable
+from druglab.db.conformer import ConformerTable
 
 __all__ = [
     "BaseTable",
     "HistoryEntry",
     "MoleculeTable",
     "ReactionTable",
+    "ConformerTable",
 ]

--- a/src/druglab/db/conformer.py
+++ b/src/druglab/db/conformer.py
@@ -1,0 +1,200 @@
+"""
+druglab.db.conformer
+~~~~~~~~~~~~~~~~~~~~
+ConformerTable: a MoleculeTable where every row holds exactly one conformer.
+
+Workflow
+--------
+1.  ``MoleculeTable.unroll_conformers()``   → ConformerTable   (explode)
+2.  Run any druglab.pipe pipeline on the ConformerTable (filter, featurize …)
+3.  ``ConformerTable.collapse()``           → MoleculeTable    (fold back)
+    or
+    ``MoleculeTable.update_from_conformers(conf_table)``       (in-place merge)
+
+Design constraints
+------------------
+* ConformerTable stores NO reference to its parent MoleculeTable — fully decoupled.
+* Each ``Chem.Mol`` in ``_objects`` carries exactly one conformer.
+* Features are initialised empty on creation to avoid OOM from copying large arrays.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from druglab.db.base import HistoryEntry
+from druglab.db.molecule import MoleculeTable, _require_rdkit
+
+try:
+    from rdkit import Chem
+    _RDKIT = True
+except ImportError:
+    _RDKIT = False
+
+
+class ConformerTable(MoleculeTable):
+    """
+    A MoleculeTable variant where every row represents a single conformer.
+
+    Each ``Chem.Mol`` in ``objects`` is guaranteed to hold exactly one
+    conformer.  All existing MoleculeTable pipelines, featurizers and IO
+    tools work on ConformerTable without modification.
+
+    Typical usage
+    -------------
+    >>> conf_table = mol_table.unroll_conformers()
+    >>> conf_table = pipeline.run(conf_table)          # filter / featurize
+    >>> mol_table_3d = conf_table.collapse("parent_index")
+    """
+
+    # ------------------------------------------------------------------
+    # Collapse: fold conformers back into a MoleculeTable
+    # ------------------------------------------------------------------
+
+    def collapse(
+        self,
+        groupby: str = "parent_index",
+        metadata_agg: Optional[Dict[str, str]] = None,
+        features_agg: Optional[Dict[str, str]] = None,
+    ) -> "MoleculeTable":
+        """
+        Pack single-conformer rows back into multi-conformer molecules.
+
+        Parameters
+        ----------
+        groupby
+            Metadata column used to identify which rows belong to the same
+            parent molecule.  Defaults to ``"parent_index"``.
+        metadata_agg
+            Aggregation rules for scalar metadata columns, passed directly to
+            ``pandas.GroupBy.agg()``.  Example: ``{"Energy": "min"}``.
+            Columns not listed here get their first value.
+        features_agg
+            Aggregation rules for feature arrays.  Supported operations:
+            ``"mean"``, ``"min"``, ``"max"``, ``"sum"``, ``"first"``, ``"last"``.
+            Example: ``{"shape_fp": "mean"}``.
+
+        Returns
+        -------
+        MoleculeTable
+            A fresh MoleculeTable with multi-conformer Mol objects.
+        """
+        _require_rdkit()
+
+        if groupby not in self._metadata.columns:
+            raise ValueError(
+                f"Column '{groupby}' not found in metadata. "
+                f"Available columns: {list(self._metadata.columns)}"
+            )
+
+        meta_agg = metadata_agg or {}
+        feat_agg = features_agg or {}
+
+        # Group row indices by parent key
+        groups: Dict = {}
+        for row_idx, key in enumerate(self._metadata[groupby]):
+            groups.setdefault(key, []).append(row_idx)
+
+        new_objects: List[Optional[Chem.Mol]] = []
+        new_meta_rows: List[dict] = []
+        new_features: Dict[str, List[np.ndarray]] = {k: [] for k in self._features}
+
+        for key in sorted(groups.keys(), key=lambda x: (isinstance(x, float), x)):
+            row_indices = groups[key]
+
+            # --- Rebuild multi-conformer Mol ---
+            base_mol = self._objects[row_indices[0]]
+            if base_mol is None:
+                new_objects.append(None)
+            else:
+                merged = Chem.RWMol(Chem.Mol(base_mol))
+                # Already has the first conformer from base_mol
+                for idx in row_indices[1:]:
+                    other = self._objects[idx]
+                    if other is None or other.GetNumConformers() == 0:
+                        continue
+                    conf = other.GetConformer(0)
+                    merged.AddConformer(conf, assignId=True)
+                new_objects.append(merged.GetMol())
+
+            # --- Aggregate metadata ---
+            group_df = self._metadata.iloc[row_indices]
+            row_dict: dict = {}
+            for col in group_df.columns:
+                if col == groupby:
+                    row_dict[col] = key
+                    continue
+                agg_fn = meta_agg.get(col, "first")
+                col_vals = group_df[col]
+                if agg_fn == "first":
+                    row_dict[col] = col_vals.iloc[0]
+                elif agg_fn == "last":
+                    row_dict[col] = col_vals.iloc[-1]
+                elif agg_fn == "min":
+                    row_dict[col] = col_vals.min()
+                elif agg_fn == "max":
+                    row_dict[col] = col_vals.max()
+                elif agg_fn == "mean":
+                    row_dict[col] = col_vals.mean()
+                elif agg_fn == "sum":
+                    row_dict[col] = col_vals.sum()
+                elif callable(agg_fn):
+                    row_dict[col] = agg_fn(col_vals)
+                else:
+                    row_dict[col] = col_vals.iloc[0]
+            new_meta_rows.append(row_dict)
+
+            # --- Aggregate features ---
+            for feat_name, feat_array in self._features.items():
+                agg_fn = feat_agg.get(feat_name, "mean")
+                group_feats = feat_array[row_indices]
+                if agg_fn == "mean":
+                    new_features[feat_name].append(group_feats.mean(axis=0))
+                elif agg_fn == "min":
+                    new_features[feat_name].append(group_feats.min(axis=0))
+                elif agg_fn == "max":
+                    new_features[feat_name].append(group_feats.max(axis=0))
+                elif agg_fn == "sum":
+                    new_features[feat_name].append(group_feats.sum(axis=0))
+                elif agg_fn == "first":
+                    new_features[feat_name].append(group_feats[0])
+                elif agg_fn == "last":
+                    new_features[feat_name].append(group_feats[-1])
+                else:
+                    new_features[feat_name].append(group_feats.mean(axis=0))
+
+        new_meta = pd.DataFrame(new_meta_rows).reset_index(drop=True)
+        stacked_features = {
+            k: np.stack(v, axis=0) for k, v in new_features.items() if v
+        }
+
+        history = list(self._history) + [
+            HistoryEntry.now(
+                block_name="ConformerTable.collapse",
+                config={
+                    "groupby": groupby,
+                    "metadata_agg": str(meta_agg),
+                    "features_agg": str(feat_agg),
+                },
+                rows_in=self.n,
+                rows_out=len(new_objects),
+            )
+        ]
+
+        return MoleculeTable(
+            objects=new_objects,
+            metadata=new_meta,
+            features=stacked_features,
+            history=history,
+        )
+
+    # ------------------------------------------------------------------
+    # Repr override so the class name is clear
+    # ------------------------------------------------------------------
+
+    def _object_type_name(self) -> str:
+        return "ConformerMol"

--- a/src/druglab/db/molecule.py
+++ b/src/druglab/db/molecule.py
@@ -9,6 +9,7 @@ require RDKit raise ``ImportError`` at call time.
 
 from __future__ import annotations
 
+import copy
 import pickle
 from typing import Dict, Iterable, List, Optional, Sequence, Union, TYPE_CHECKING
 
@@ -26,6 +27,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from druglab.io._record import MoleculeRecord
+    from druglab.db.conformer import ConformerTable
 
 
 def _require_rdkit() -> None:
@@ -320,7 +322,256 @@ class MoleculeTable(BaseTable["Chem.Mol"]):
         return self.subset(idx)
 
     # ------------------------------------------------------------------
-    # SDF output
+    # 3D Conformer handling
+    # ------------------------------------------------------------------
+
+    def unroll_conformers(
+        self,
+        id_col: str = "parent_index",
+    ) -> "ConformerTable":
+        """
+        Explode a multi-conformer MoleculeTable into a ConformerTable where
+        every row holds exactly one conformer.
+
+        Molecules with no conformers or ``None`` entries are silently skipped.
+
+        Parameters
+        ----------
+        id_col
+            Name of the metadata column that will store the integer index of
+            the parent molecule.  Defaults to ``"parent_index"``.
+
+        Returns
+        -------
+        ConformerTable
+            A new table with one row per conformer.  Features are initialised
+            to an empty dict to avoid Out-of-Memory errors on large datasets.
+
+        Notes
+        -----
+        * Each new ``Chem.Mol`` is a fresh copy of the parent graph with
+          exactly one conformer injected, so serialisation via
+          ``mol.ToBinary()`` stays lightweight.
+        * The original ``MoleculeTable`` is **not** modified.
+        """
+        _require_rdkit()
+        from druglab.db.conformer import ConformerTable
+
+        new_objects: List[Chem.Mol] = []
+        meta_rows: List[dict] = []
+
+        for parent_idx, mol in enumerate(self._objects):
+            if mol is None or mol.GetNumConformers() == 0:
+                continue
+
+            parent_row = self._metadata.iloc[parent_idx].to_dict()
+
+            for conf in mol.GetConformers():
+                conf_id = conf.GetId()
+
+                # Build a lightweight single-conformer copy
+                single = Chem.RWMol(Chem.Mol(mol))
+                single.RemoveAllConformers()
+                # Copy must use a new Conformer object (not the same reference)
+                new_conf = Chem.Conformer(conf)
+                single.AddConformer(new_conf, assignId=True)
+
+                new_objects.append(single.GetMol())
+
+                row = dict(parent_row)
+                row[id_col] = parent_idx
+                row["conf_id"] = conf_id
+                meta_rows.append(row)
+
+        new_meta = pd.DataFrame(meta_rows).reset_index(drop=True)
+
+        history = list(self._history) + [
+            HistoryEntry.now(
+                block_name="MoleculeTable.unroll_conformers",
+                config={"id_col": id_col},
+                rows_in=self.n,
+                rows_out=len(new_objects),
+            )
+        ]
+
+        return ConformerTable(
+            objects=new_objects,
+            metadata=new_meta,
+            features={},   # intentionally empty — no OOM risk
+            history=history,
+        )
+
+    def update_from_conformers(
+        self,
+        conf_table: "ConformerTable",
+        id_col: str = "parent_index",
+        metadata_agg: Optional[Dict] = None,
+        features_agg: Optional[Dict] = None,
+        drop_empty: bool = True,
+    ) -> "MoleculeTable":
+        """
+        Merge a processed ConformerTable back into this MoleculeTable.
+
+        This allows a filtered / featurised ConformerTable to overwrite the
+        conformers and selectively update scalar properties of the parent table.
+
+        Parameters
+        ----------
+        conf_table
+            The ConformerTable produced by (and derived from) this table.
+        id_col
+            The metadata column in ``conf_table`` that maps rows back to
+            parent indices.  Must match the ``id_col`` used in
+            ``unroll_conformers()``.
+        metadata_agg
+            Aggregation rules for collapsing ConformerTable metadata into
+            parent-level scalars, e.g. ``{"Energy": "min"}``.
+            Only columns listed here are written back to the parent metadata.
+        features_agg
+            Aggregation rules for feature arrays, e.g. ``{"shape_fp": "mean"}``.
+            Supported: ``"mean"``, ``"min"``, ``"max"``, ``"sum"``,
+            ``"first"``, ``"last"``.
+            Only keys listed here are written back to the parent features.
+        drop_empty
+            If ``True`` (default), parent molecules whose conformers were all
+            filtered out of ``conf_table`` are removed from the result.
+            If ``False``, those molecules are kept but their conformer list is
+            cleared.
+
+        Returns
+        -------
+        MoleculeTable
+            A new MoleculeTable respecting functional immutability.
+        """
+        _require_rdkit()
+
+        if id_col not in conf_table.metadata.columns:
+            raise ValueError(
+                f"Column '{id_col}' not found in ConformerTable metadata. "
+                f"Available: {list(conf_table.metadata.columns)}"
+            )
+
+        meta_agg = metadata_agg or {}
+        feat_agg = features_agg or {}
+
+        # Build a mapping: parent_index -> list of conf_table row indices
+        parent_to_rows: Dict[int, List[int]] = {}
+        for row_idx, parent_idx in enumerate(conf_table.metadata[id_col]):
+            parent_to_rows.setdefault(int(parent_idx), []).append(row_idx)
+
+        # Deep-copy objects so the original table is untouched
+        new_objects = copy.deepcopy(self._objects)
+        new_meta = self._metadata.copy(deep=True)
+        new_features = {k: v.copy() for k, v in self._features.items()}
+
+        keep_mask = np.ones(self.n, dtype=bool)
+
+        for parent_idx in range(self.n):
+            mol = new_objects[parent_idx]
+            if mol is None:
+                keep_mask[parent_idx] = False
+                continue
+
+            row_indices = parent_to_rows.get(parent_idx)
+
+            if not row_indices:
+                # All conformers were filtered out for this molecule
+                if drop_empty:
+                    keep_mask[parent_idx] = False
+                else:
+                    mol.RemoveAllConformers()
+                continue
+
+            # Inject surviving conformers back into the parent mol
+            mol.RemoveAllConformers()
+            for ri in row_indices:
+                conf_mol = conf_table.objects[ri]
+                if conf_mol is None or conf_mol.GetNumConformers() == 0:
+                    continue
+                conf = conf_mol.GetConformer(0)
+                mol.AddConformer(Chem.Conformer(conf), assignId=True)
+
+            # Aggregate metadata columns back
+            group_df = conf_table.metadata.iloc[row_indices]
+            for col, agg_fn in meta_agg.items():
+                if col not in group_df.columns:
+                    continue
+                col_vals = group_df[col]
+                if agg_fn == "first":
+                    val = col_vals.iloc[0]
+                elif agg_fn == "last":
+                    val = col_vals.iloc[-1]
+                elif agg_fn == "min":
+                    val = col_vals.min()
+                elif agg_fn == "max":
+                    val = col_vals.max()
+                elif agg_fn == "mean":
+                    val = col_vals.mean()
+                elif agg_fn == "sum":
+                    val = col_vals.sum()
+                elif callable(agg_fn):
+                    val = agg_fn(col_vals)
+                else:
+                    val = col_vals.iloc[0]
+                new_meta.at[parent_idx, col] = val
+
+            # Aggregate feature arrays back
+            for feat_name, agg_fn in feat_agg.items():
+                if feat_name not in conf_table.features:
+                    continue
+                feat_arr = conf_table.features[feat_name]
+                group_feats = feat_arr[row_indices]
+                if agg_fn == "mean":
+                    agg_val = group_feats.mean(axis=0)
+                elif agg_fn == "min":
+                    agg_val = group_feats.min(axis=0)
+                elif agg_fn == "max":
+                    agg_val = group_feats.max(axis=0)
+                elif agg_fn == "sum":
+                    agg_val = group_feats.sum(axis=0)
+                elif agg_fn == "first":
+                    agg_val = group_feats[0]
+                elif agg_fn == "last":
+                    agg_val = group_feats[-1]
+                else:
+                    agg_val = group_feats.mean(axis=0)
+
+                if feat_name not in new_features:
+                    # Initialise feature array with zeros (correct shape from conf_table)
+                    new_features[feat_name] = np.zeros(
+                        (self.n,) + agg_val.shape, dtype=agg_val.dtype
+                    )
+                new_features[feat_name][parent_idx] = agg_val
+
+        # Apply the keep mask
+        keep_indices = np.where(keep_mask)[0]
+        filtered_objects = [new_objects[i] for i in keep_indices]
+        filtered_meta = new_meta.iloc[keep_indices].reset_index(drop=True)
+        filtered_features = {k: v[keep_indices] for k, v in new_features.items()}
+
+        history = list(self._history) + [
+            HistoryEntry.now(
+                block_name="MoleculeTable.update_from_conformers",
+                config={
+                    "id_col": id_col,
+                    "drop_empty": drop_empty,
+                    "metadata_agg": str(meta_agg),
+                    "features_agg": str(feat_agg),
+                },
+                rows_in=self.n,
+                rows_out=len(filtered_objects),
+            )
+        ]
+
+        return MoleculeTable(
+            objects=filtered_objects,
+            metadata=filtered_meta,
+            features=filtered_features,
+            history=history,
+        )
+
+    # ------------------------------------------------------------------
+    # SDF output (kept for backward compat — to_file is the preferred API)
     # ------------------------------------------------------------------
 
     def to_sdf(self, path: str) -> None:

--- a/src/druglab/pipe/pipeline.py
+++ b/src/druglab/pipe/pipeline.py
@@ -4,10 +4,11 @@ druglab.pipe.pipeline
 Pipeline orchestrator that manages block execution and batch boundaries.
 """
 
-from typing import List, Optional, Iterator
+from typing import List, Optional, Iterator, TypeVar
 from druglab.db.base import BaseTable
 from druglab.pipe.base import BaseBlock
 
+TableT = TypeVar("T", bound="BaseTable")
 
 class Pipeline:
     """
@@ -18,11 +19,11 @@ class Pipeline:
     def __init__(self, steps: List[BaseBlock]):
         self.steps = steps
 
-    def run(self, table: Optional[BaseTable] = None) -> BaseTable:
+    def run(self, table: Optional[TableT] = None) -> TableT:
         """Run the pipeline on an initial table (or None if starting with an IO block)."""
         return self._run_steps(self.steps, table)
 
-    def _run_steps(self, steps: List[BaseBlock], table: Optional[BaseTable]) -> BaseTable:
+    def _run_steps(self, steps: List[BaseBlock], table: Optional[TableT]) -> TableT:
         if not steps:
             return table
 
@@ -60,7 +61,7 @@ class Pipeline:
             out_table = current_step.run(table)
             return self._run_steps(remaining_steps, out_table)
 
-    def _chunk_table(self, table: BaseTable, batch_size: int) -> Iterator[BaseTable]:
+    def _chunk_table(self, table: TableT, batch_size: int) -> Iterator[TableT]:
         """Helper to yield slices of a BaseTable."""
         n = len(table)
         for i in range(0, n, batch_size):

--- a/tests/test_db_conformer.py
+++ b/tests/test_db_conformer.py
@@ -1,5 +1,5 @@
 """
-tests/test_conformer.py
+tests/test_db_conformer.py
 ~~~~~~~~~~~~~~~~~~~~~~~
 Tests for ConformerTable and the conformer bridging methods on MoleculeTable.
 

--- a/tests/test_db_conformer.py
+++ b/tests/test_db_conformer.py
@@ -1,0 +1,525 @@
+"""
+tests/test_conformer.py
+~~~~~~~~~~~~~~~~~~~~~~~
+Tests for ConformerTable and the conformer bridging methods on MoleculeTable.
+
+These tests require a real RDKit installation because they exercise actual
+3D coordinate manipulation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Make sure the local src is importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# ---------------------------------------------------------------------------
+# RDKit availability guard
+# ---------------------------------------------------------------------------
+
+try:
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+    _RDKIT = True
+except ImportError:
+    _RDKIT = False
+
+pytestmark = pytest.mark.skipif(not _RDKIT, reason="RDKit not installed")
+
+from druglab.db.molecule import MoleculeTable
+from druglab.db.conformer import ConformerTable
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mol_with_conformers(smiles: str, n_confs: int = 3, seed: int = 42) -> "Chem.Mol":
+    """Return an RDKit Mol with ``n_confs`` embedded 3D conformers."""
+    mol = Chem.MolFromSmiles(smiles)
+    assert mol is not None, f"Bad SMILES: {smiles}"
+    mol = Chem.AddHs(mol)
+    params = AllChem.EmbedMultipleConfs(
+        mol, numConfs=n_confs, randomSeed=seed, numThreads=1
+    )
+    assert mol.GetNumConformers() > 0, "Embedding failed"
+    return mol
+
+
+def _simple_3d_table(n_mols: int = 2, n_confs_each: int = 3) -> MoleculeTable:
+    """Build a small MoleculeTable with 3D conformers."""
+    smiles_list = ["CCO", "c1ccccc1", "CC(=O)O", "CCC"]
+    mols = [
+        _mol_with_conformers(smiles_list[i % len(smiles_list)], n_confs=n_confs_each)
+        for i in range(n_mols)
+    ]
+    meta = pd.DataFrame({
+        "name": [f"mol_{i}" for i in range(n_mols)],
+        "activity": [float(i) for i in range(n_mols)],
+    })
+    return MoleculeTable(objects=mols, metadata=meta)
+
+
+# ===========================================================================
+# Section 1: unroll_conformers
+# ===========================================================================
+
+class TestUnrollConformers:
+
+    def test_row_count(self):
+        """Each conformer becomes exactly one row."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        assert conf_table.n == 6  # 2 mols × 3 confs
+
+    def test_returns_conformer_table_type(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        assert isinstance(conf_table, ConformerTable)
+
+    def test_each_object_has_exactly_one_conformer(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        for mol in conf_table.objects:
+            assert mol is not None
+            assert mol.GetNumConformers() == 1
+
+    def test_parent_index_column_created(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        assert "parent_index" in conf_table.metadata.columns
+
+    def test_conf_id_column_created(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        assert "conf_id" in conf_table.metadata.columns
+
+    def test_custom_id_col_name(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers(id_col="mol_id")
+        assert "mol_id" in conf_table.metadata.columns
+        assert "parent_index" not in conf_table.metadata.columns
+
+    def test_parent_metadata_duplicated(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        # mol_0 should appear 3 times (once per conformer)
+        mol0_rows = conf_table.metadata[conf_table.metadata["parent_index"] == 0]
+        assert len(mol0_rows) == 3
+        assert all(mol0_rows["name"] == "mol_0")
+
+    def test_features_empty(self):
+        """Features must not be copied to prevent OOM on large datasets."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        # Add a heavy feature to the parent
+        table.add_feature("fp", np.ones((2, 1024)))
+        conf_table = table.unroll_conformers()
+        assert conf_table.features == {}
+
+    def test_history_entry_added(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        block_names = [e.block_name for e in conf_table.history]
+        assert "MoleculeTable.unroll_conformers" in block_names
+
+    def test_none_mol_skipped(self):
+        """None entries in the parent table are silently skipped."""
+        mol = _mol_with_conformers("CCO", n_confs=2)
+        table = MoleculeTable(
+            objects=[None, mol],
+            metadata=pd.DataFrame({"name": ["bad", "good"]}),
+        )
+        conf_table = table.unroll_conformers()
+        assert conf_table.n == 2  # only from the valid mol
+
+    def test_mol_with_no_conformers_skipped(self):
+        mol_2d = Chem.MolFromSmiles("CCO")  # 2D, no conformer
+        mol_3d = _mol_with_conformers("CCO", n_confs=2)
+        table = MoleculeTable(
+            objects=[mol_2d, mol_3d],
+            metadata=pd.DataFrame({"name": ["flat", "3d"]}),
+        )
+        conf_table = table.unroll_conformers()
+        assert conf_table.n == 2  # only from mol_3d
+
+    def test_original_table_unchanged(self):
+        """unroll_conformers must not modify the parent table."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        n_before = table.n
+        conf_before = table.objects[0].GetNumConformers()
+        _ = table.unroll_conformers()
+        assert table.n == n_before
+        assert table.objects[0].GetNumConformers() == conf_before
+
+    def test_coordinates_are_distinct(self):
+        """Each single-conformer copy must carry the correct coordinates."""
+        mol = _mol_with_conformers("c1ccccc1", n_confs=3)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["benzene"]}),
+        )
+        conf_table = table.unroll_conformers()
+
+        # Collect the first-atom positions from each row
+        positions = []
+        for m in conf_table.objects:
+            pos = m.GetConformer(0).GetAtomPosition(0)
+            positions.append((pos.x, pos.y, pos.z))
+
+        # The three conformers should generally have different coordinates
+        # (they're randomly seeded embeddings)
+        assert len(set(positions)) > 1
+
+
+# ===========================================================================
+# Section 2: ConformerTable.collapse
+# ===========================================================================
+
+class TestCollapse:
+
+    def test_roundtrip_row_count(self):
+        """collapse() should restore one row per parent molecule."""
+        table = _simple_3d_table(n_mols=3, n_confs_each=4)
+        conf_table = table.unroll_conformers()
+        collapsed = conf_table.collapse(groupby="parent_index")
+        assert collapsed.n == 3
+
+    def test_returns_molecule_table_type(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        collapsed = conf_table.collapse()
+        assert type(collapsed) is MoleculeTable
+
+    def test_conformer_count_restored(self):
+        """Each molecule in the collapsed table should regain all conformers."""
+        n_confs = 4
+        table = _simple_3d_table(n_mols=2, n_confs_each=n_confs)
+        conf_table = table.unroll_conformers()
+        collapsed = conf_table.collapse()
+        for mol in collapsed.objects:
+            assert mol is not None
+            assert mol.GetNumConformers() == n_confs
+
+    def test_metadata_aggregation_min(self):
+        """metadata_agg rules should be applied correctly."""
+        mol = _mol_with_conformers("CCO", n_confs=3)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["ethanol"]}),
+        )
+        conf_table = table.unroll_conformers()
+        # Inject fake energies into the ConformerTable metadata
+        conf_table.add_metadata_column("Energy", [10.0, 3.0, 7.0])
+        collapsed = conf_table.collapse(metadata_agg={"Energy": "min"})
+        assert collapsed.metadata["Energy"].iloc[0] == pytest.approx(3.0)
+
+    def test_metadata_aggregation_mean(self):
+        mol = _mol_with_conformers("CCO", n_confs=4)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["ethanol"]}),
+        )
+        conf_table = table.unroll_conformers()
+        conf_table.add_metadata_column("Score", [0.0, 2.0, 4.0, 6.0])
+        collapsed = conf_table.collapse(metadata_agg={"Score": "mean"})
+        assert collapsed.metadata["Score"].iloc[0] == pytest.approx(3.0)
+
+    def test_features_aggregation(self):
+        """features_agg rules should correctly stack and aggregate arrays."""
+        mol = _mol_with_conformers("CCO", n_confs=3)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["ethanol"]}),
+        )
+        conf_table = table.unroll_conformers()
+        # Add fake 3D features manually
+        fake_feats = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        conf_table.add_feature("desc3d", fake_feats)
+
+        collapsed = conf_table.collapse(features_agg={"desc3d": "mean"})
+        expected = fake_feats.mean(axis=0)
+        assert np.allclose(collapsed.features["desc3d"][0], expected)
+
+    def test_history_entry_added(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        collapsed = conf_table.collapse()
+        block_names = [e.block_name for e in collapsed.history]
+        assert "ConformerTable.collapse" in block_names
+
+    def test_invalid_groupby_column_raises(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        with pytest.raises(ValueError, match="nonexistent"):
+            conf_table.collapse(groupby="nonexistent")
+
+    def test_partial_collapse_after_filter(self):
+        """Collapse after filtering some conformers out."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=4)
+        conf_table = table.unroll_conformers()
+
+        # Keep only conformers whose conf_id < 2 (first two per molecule)
+        mask = conf_table.metadata["conf_id"] < 2
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        collapsed = filtered.collapse(groupby="parent_index")
+        assert collapsed.n == 2
+        for mol in collapsed.objects:
+            assert mol.GetNumConformers() == 2
+
+
+# ===========================================================================
+# Section 3: MoleculeTable.update_from_conformers
+# ===========================================================================
+
+class TestUpdateFromConformers:
+
+    def test_returns_new_molecule_table(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        result = table.update_from_conformers(conf_table)
+        assert isinstance(result, MoleculeTable)
+        assert result is not table
+
+    def test_original_table_unchanged(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        n_before = table.n
+        _ = table.update_from_conformers(conf_table)
+        assert table.n == n_before
+
+    def test_conformers_round_trip(self):
+        """All conformers should be restored when no filtering occurs."""
+        n_confs = 3
+        table = _simple_3d_table(n_mols=2, n_confs_each=n_confs)
+        conf_table = table.unroll_conformers()
+        result = table.update_from_conformers(conf_table)
+        for mol in result.objects:
+            assert mol.GetNumConformers() == n_confs
+
+    def test_drop_empty_true(self):
+        """Molecules whose conformers were all filtered out are dropped."""
+        table = _simple_3d_table(n_mols=3, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+
+        # Keep only conformers from parent molecule 0 and 2
+        mask = conf_table.metadata["parent_index"].isin([0, 2])
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        result = table.update_from_conformers(filtered, drop_empty=True)
+        assert result.n == 2
+
+    def test_drop_empty_false(self):
+        """Molecules whose conformers were filtered are kept with empty conformers."""
+        table = _simple_3d_table(n_mols=3, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+
+        # Keep only conformers from parent molecule 0
+        mask = conf_table.metadata["parent_index"] == 0
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        result = table.update_from_conformers(filtered, drop_empty=False)
+        assert result.n == 3
+        # Mol 1 and 2 should have 0 conformers
+        assert result.objects[1].GetNumConformers() == 0
+        assert result.objects[2].GetNumConformers() == 0
+
+    def test_metadata_aggregation_written_back(self):
+        """Aggregated metadata from conf_table should be merged into parent."""
+        mol = _mol_with_conformers("CCO", n_confs=3)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["ethanol"], "energy": [999.0]}),
+        )
+        conf_table = table.unroll_conformers()
+        conf_table.add_metadata_column("energy", [5.0, 2.0, 8.0])
+
+        result = table.update_from_conformers(
+            conf_table, metadata_agg={"energy": "min"}
+        )
+        assert result.metadata["energy"].iloc[0] == pytest.approx(2.0)
+
+    def test_feature_aggregation_written_back(self):
+        """Aggregated features from conf_table should appear in result."""
+        mol = _mol_with_conformers("CCO", n_confs=3)
+        table = MoleculeTable(
+            objects=[mol],
+            metadata=pd.DataFrame({"name": ["ethanol"]}),
+        )
+        conf_table = table.unroll_conformers()
+        fake_feats = np.array([[1.0, 0.0], [3.0, 0.0], [5.0, 0.0]])
+        conf_table.add_feature("shape", fake_feats)
+
+        result = table.update_from_conformers(
+            conf_table, features_agg={"shape": "mean"}
+        )
+        assert "shape" in result.features
+        expected = fake_feats.mean(axis=0)
+        assert np.allclose(result.features["shape"][0], expected)
+
+    def test_history_entry_added(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        result = table.update_from_conformers(conf_table)
+        block_names = [e.block_name for e in result.history]
+        assert "MoleculeTable.update_from_conformers" in block_names
+
+    def test_invalid_id_col_raises(self):
+        table = _simple_3d_table(n_mols=1, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        with pytest.raises(ValueError, match="bad_col"):
+            table.update_from_conformers(conf_table, id_col="bad_col")
+
+    def test_filtering_reduces_conformer_count(self):
+        """Filtering down to 1 conformer per molecule updates counts correctly."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=4)
+        conf_table = table.unroll_conformers()
+
+        # Keep only the first conformer per molecule
+        mask = conf_table.metadata["conf_id"] == conf_table.metadata["conf_id"].min()
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        result = table.update_from_conformers(filtered)
+        assert result.n == 2
+        for mol in result.objects:
+            assert mol.GetNumConformers() == 1
+
+
+# ===========================================================================
+# Section 4: ConformerTable as a MoleculeTable subclass
+# ===========================================================================
+
+class TestConformerTableInheritance:
+
+    def test_is_molecule_table_subclass(self):
+        assert issubclass(ConformerTable, MoleculeTable)
+
+    def test_pipeline_works_on_conformer_table(self):
+        """Standard druglab.pipe blocks should work on a ConformerTable."""
+        from druglab.pipe import Pipeline, FunctionFilter
+
+        table = _simple_3d_table(n_mols=3, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+
+        # Keep only conformers with conf_id == 0
+        pipe = Pipeline([
+            FunctionFilter(func=lambda mol: mol is not None)
+        ])
+        result = pipe.run(conf_table)
+        assert isinstance(result, ConformerTable)
+
+    def test_subset_preserves_type(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        sub = conf_table.subset([0, 1, 2])
+        assert isinstance(sub, ConformerTable)
+
+    def test_concat_preserves_type(self):
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        ct1 = table.unroll_conformers()
+        ct2 = table.unroll_conformers()
+        combined = ConformerTable.concat([ct1, ct2])
+        assert isinstance(combined, ConformerTable)
+
+    def test_no_reference_to_parent(self):
+        """ConformerTable must not store a reference to the parent table."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        # Deleting the parent should not affect the ConformerTable
+        del table
+        assert conf_table.n == 4
+
+    def test_decoupled_from_parent(self):
+        """Mutating the parent table should not affect the ConformerTable."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=2)
+        conf_table = table.unroll_conformers()
+        # Mutate parent metadata
+        table._metadata.loc[0, "name"] = "MUTATED"
+        # ConformerTable should still have original values
+        assert "MUTATED" not in conf_table.metadata["name"].values
+
+
+# ===========================================================================
+# Section 5: Full end-to-end workflow
+# ===========================================================================
+
+class TestEndToEnd:
+
+    def test_full_explode_filter_collapse_workflow(self):
+        """
+        Realistic workflow:
+        1. Build 3D table
+        2. Unroll conformers
+        3. Filter to keep only the first 2 conformers per molecule
+        4. Collapse back
+        """
+        n_mols = 3
+        n_confs = 5
+        table = _simple_3d_table(n_mols=n_mols, n_confs_each=n_confs)
+        conf_table = table.unroll_conformers()
+
+        assert conf_table.n == n_mols * n_confs
+
+        # Filter: keep only conf_ids 0 and 1
+        mask = conf_table.metadata["conf_id"].isin([0, 1])
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        assert filtered.n == n_mols * 2
+
+        collapsed = filtered.collapse(groupby="parent_index")
+        assert collapsed.n == n_mols
+        for mol in collapsed.objects:
+            assert mol.GetNumConformers() == 2
+
+    def test_full_explode_filter_update_workflow(self):
+        """
+        Realistic workflow using update_from_conformers instead of collapse.
+        """
+        n_mols = 3
+        n_confs = 4
+        table = _simple_3d_table(n_mols=n_mols, n_confs_each=n_confs)
+
+        # Add some fake energy data
+        table.add_metadata_column("best_energy", [0.0] * n_mols)
+        conf_table = table.unroll_conformers()
+
+        # Inject fake energies per conformer
+        rng = np.random.default_rng(seed=0)
+        energies = rng.uniform(0, 10, size=conf_table.n).tolist()
+        conf_table.add_metadata_column("energy", energies)
+
+        # Filter: drop highest-energy conformers (keep energy < 8)
+        mask = np.array(energies) < 8.0
+        filtered = conf_table.subset(np.where(mask)[0])
+
+        result = table.update_from_conformers(
+            filtered, metadata_agg={"energy": "min"}, drop_empty=True
+        )
+
+        # All surviving molecules should have min energy < 8
+        for val in result.metadata["energy"]:
+            assert val < 8.0
+
+    def test_history_audit_trail(self):
+        """The full audit trail should be preserved across the pipeline."""
+        table = _simple_3d_table(n_mols=2, n_confs_each=3)
+        conf_table = table.unroll_conformers()
+        collapsed = conf_table.collapse()
+
+        block_names = [e.block_name for e in collapsed.history]
+        assert "MoleculeTable.unroll_conformers" in block_names
+        assert "ConformerTable.collapse" in block_names
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This PR introduces native 3D conformer support to `druglab` using a robust "Explode and Collapse" projection architecture. This design ensures full compatibility with existing multiprocessing pipelines while strictly preventing memory bloat and maintaining functional immutability.

**Key Changes:**
* **`ConformerTable` (New):** A standalone table subclass where every row represents exactly one conformer, allowing 3D ensembles to pass seamlessly through standard pipeline blocks.
* **Explode (`MoleculeTable.unroll_conformers`):** Unrolls a 2D multi-conformer molecule into a 3D table. Employs a "Fat Metadata, Thin Features" strategy—cheap scalar metadata is duplicated, but heavy 2D feature arrays are dropped to prevent IPC overhead and Out-Of-Memory (OOM) errors during multiprocessing.
* **Collapse (`MoleculeTable.update_from_conformers` & `ConformerTable.collapse`):** Merges processed 3D conformers back into the 2D parent table using explicit aggregation rules (e.g., `{"Energy": "min"}`). 
* **Audit Trail Preserved:** Fully decoupled design ensures `HistoryEntry` logs remain accurate and reproducible across all dimensional transitions.

**Tests:**
* **`tests/test_db_conformer.py`**